### PR TITLE
Add method of difference and 10x10 support

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -10,13 +10,18 @@ import {
 } from "@/components/ui/select"
 import { Slider } from "@/components/ui/slider"
 import { primePowerDecomposition } from "@/lib/finite-field"
-import { areMultipliersValid, getAllMultipliers } from "@/lib/graeco-latin"
+import {
+  areMultipliersValid,
+  getAllMultipliers,
+  isMethodOfDifferenceSupported,
+} from "@/lib/graeco-latin"
 import {
   GRAYSCALE_PALETTE,
   PASTEL_PALETTE,
   SCIENTIFIC_AMERICAN_59_PALETTE,
   shiftPalette,
 } from "@/lib/palettes"
+import type { Method } from "@/lib/store"
 import { useGraecoLatinStore } from "@/lib/store"
 
 export default function Controls() {
@@ -42,8 +47,7 @@ export default function Controls() {
 
   const handleSizeChange = (newSize: number) => {
     setSize(newSize)
-    const m = (newSize - 1) / 3
-    const diffValid = Number.isInteger(m) && m % 2 === 1 && m >= 1
+    const diffValid = isMethodOfDifferenceSupported(newSize)
     if (method === "difference" && !diffValid) setMethod("auto")
     if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
     if (newSize !== 4 && method === "klein4") setMethod("auto")
@@ -111,12 +115,7 @@ export default function Controls() {
 
             <div>
               <Label htmlFor="method">Construction Method</Label>
-              <Select
-                value={method}
-                onValueChange={(value) =>
-                  setMethod(value as "auto" | "finite" | "cyclic" | "klein4" | "difference")
-                }
-              >
+              <Select value={method} onValueChange={(value) => setMethod(value as Method)}>
                 <SelectTrigger className="bg-white mt-2">
                   <SelectValue />
                 </SelectTrigger>
@@ -131,11 +130,8 @@ export default function Controls() {
                   <SelectItem value="klein4" disabled={size !== 4}>
                     Klein 4 (4×4)
                   </SelectItem>
-                  <SelectItem
-                    value="difference"
-                    disabled={!(Number.isInteger((size - 1) / 3) && ((size - 1) / 3) % 2 === 1)}
-                  >
-                    Method of Difference (n = 3m + 1, m odd)
+                  <SelectItem value="difference" disabled={!isMethodOfDifferenceSupported(size)}>
+                    Method of Difference
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -42,7 +42,9 @@ export default function Controls() {
 
   const handleSizeChange = (newSize: number) => {
     setSize(newSize)
-    if (newSize === 10) setMethod("difference")
+    const m = (newSize - 1) / 3
+    const diffValid = Number.isInteger(m) && m % 2 === 1 && m >= 1
+    if (diffValid) setMethod("difference")
     else {
       if (method === "difference") setMethod("auto")
       if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
@@ -134,8 +136,11 @@ export default function Controls() {
                   <SelectItem value="klein4" disabled={size !== 4}>
                     Klein 4 (4×4)
                   </SelectItem>
-                  <SelectItem value="difference" disabled={size !== 10}>
-                    Method of Difference (10×10)
+                  <SelectItem
+                    value="difference"
+                    disabled={!(Number.isInteger((size - 1) / 3) && ((size - 1) / 3) % 2 === 1)}
+                  >
+                    Method of Difference (n = 3m + 1, m odd)
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -42,9 +42,13 @@ export default function Controls() {
 
   const handleSizeChange = (newSize: number) => {
     setSize(newSize)
-    if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
-    if (newSize !== 4 && method === "klein4") setMethod("auto")
-    if (!primePowerDecomposition(newSize) && method === "finite") setMethod("auto")
+    if (newSize === 10) setMethod("difference")
+    else {
+      if (method === "difference") setMethod("auto")
+      if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
+      if (newSize !== 4 && method === "klein4") setMethod("auto")
+      if (!primePowerDecomposition(newSize) && method === "finite") setMethod("auto")
+    }
     const newMultipliers = getAllMultipliers(newSize)
     if (!newMultipliers.includes(latinMultiplier)) {
       setLatinMultiplier(newMultipliers[0] || 1)
@@ -101,6 +105,7 @@ export default function Controls() {
                   <SelectItem value="7">7×7</SelectItem>
                   <SelectItem value="8">8×8</SelectItem>
                   <SelectItem value="9">9×9</SelectItem>
+                  <SelectItem value="10">10×10</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -110,22 +115,27 @@ export default function Controls() {
               <Select
                 value={method}
                 onValueChange={(value) =>
-                  setMethod(value as "auto" | "finite" | "cyclic" | "klein4")
+                  setMethod(value as "auto" | "finite" | "cyclic" | "klein4" | "difference")
                 }
               >
                 <SelectTrigger className="bg-white mt-2">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="auto">Auto</SelectItem>
-                  <SelectItem value="finite" disabled={!isPrimePower}>
+                  <SelectItem value="auto" disabled={size === 10}>
+                    Auto
+                  </SelectItem>
+                  <SelectItem value="finite" disabled={!isPrimePower || size === 10}>
                     Finite Field
                   </SelectItem>
-                  <SelectItem value="cyclic" disabled={size % 2 === 0}>
+                  <SelectItem value="cyclic" disabled={size % 2 === 0 || size === 10}>
                     Cyclic
                   </SelectItem>
                   <SelectItem value="klein4" disabled={size !== 4}>
                     Klein 4 (4×4)
+                  </SelectItem>
+                  <SelectItem value="difference" disabled={size !== 10}>
+                    Method of Difference (10×10)
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -44,13 +44,10 @@ export default function Controls() {
     setSize(newSize)
     const m = (newSize - 1) / 3
     const diffValid = Number.isInteger(m) && m % 2 === 1 && m >= 1
-    if (diffValid) setMethod("difference")
-    else {
-      if (method === "difference") setMethod("auto")
-      if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
-      if (newSize !== 4 && method === "klein4") setMethod("auto")
-      if (!primePowerDecomposition(newSize) && method === "finite") setMethod("auto")
-    }
+    if (method === "difference" && !diffValid) setMethod("auto")
+    if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
+    if (newSize !== 4 && method === "klein4") setMethod("auto")
+    if (!primePowerDecomposition(newSize) && method === "finite") setMethod("auto")
     const newMultipliers = getAllMultipliers(newSize)
     if (!newMultipliers.includes(latinMultiplier)) {
       setLatinMultiplier(newMultipliers[0] || 1)
@@ -124,13 +121,11 @@ export default function Controls() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="auto" disabled={size === 10}>
-                    Auto
-                  </SelectItem>
-                  <SelectItem value="finite" disabled={!isPrimePower || size === 10}>
+                  <SelectItem value="auto">Auto</SelectItem>
+                  <SelectItem value="finite" disabled={!isPrimePower}>
                     Finite Field
                   </SelectItem>
-                  <SelectItem value="cyclic" disabled={size % 2 === 0 || size === 10}>
+                  <SelectItem value="cyclic" disabled={size % 2 === 0}>
                     Cyclic
                   </SelectItem>
                   <SelectItem value="klein4" disabled={size !== 4}>

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -10,6 +10,7 @@ import {
   generateGraecoLatinAuto,
   generateKlein4GraecoLatin,
   generateMethodOfDifferenceGraecoLatin,
+  isMethodOfDifferenceSupported,
 } from "@/lib/graeco-latin"
 import {
   GRAYSCALE_PALETTE,
@@ -37,7 +38,7 @@ export default function Display() {
     square = generateKlein4GraecoLatin()
   } else if (method === "difference") {
     const m = (size - 1) / 3
-    if (Number.isInteger(m) && m % 2 === 1 && m >= 1) {
+    if (isMethodOfDifferenceSupported(size)) {
       square = generateMethodOfDifferenceGraecoLatin(m)
     } else {
       square = generateGraecoLatinAuto(size, { latinMultiplier, greekMultiplier })

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -35,8 +35,13 @@ export default function Display() {
   let square: GraecoLatinSquare
   if (method === "klein4" && size === 4) {
     square = generateKlein4GraecoLatin()
-  } else if (method === "difference" && size === 10) {
-    square = generateMethodOfDifferenceGraecoLatin(3)
+  } else if (method === "difference") {
+    const m = (size - 1) / 3
+    if (Number.isInteger(m) && m % 2 === 1 && m >= 1) {
+      square = generateMethodOfDifferenceGraecoLatin(m)
+    } else {
+      square = generateGraecoLatinAuto(size, { latinMultiplier, greekMultiplier })
+    }
   } else if (method === "finite") {
     const ff = generateFiniteFieldGraecoLatin(size)
     if (ff) square = ff

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -9,6 +9,7 @@ import {
   generateFiniteFieldGraecoLatin,
   generateGraecoLatinAuto,
   generateKlein4GraecoLatin,
+  generateMethodOfDifferenceGraecoLatin,
 } from "@/lib/graeco-latin"
 import {
   GRAYSCALE_PALETTE,
@@ -34,6 +35,8 @@ export default function Display() {
   let square: GraecoLatinSquare
   if (method === "klein4" && size === 4) {
     square = generateKlein4GraecoLatin()
+  } else if (method === "difference" && size === 10) {
+    square = generateMethodOfDifferenceGraecoLatin(3)
   } else if (method === "finite") {
     const ff = generateFiniteFieldGraecoLatin(size)
     if (ff) square = ff

--- a/src/lib/graeco-latin.test.ts
+++ b/src/lib/graeco-latin.test.ts
@@ -5,6 +5,7 @@ import {
   generateFiniteFieldGraecoLatin,
   generateGraecoLatinAuto,
   generateKlein4GraecoLatin,
+  generateMethodOfDifferenceGraecoLatin,
   getAllMultipliers,
 } from "./graeco-latin"
 
@@ -109,6 +110,78 @@ describe("generateCyclicGraecoLatin", () => {
   it("throws for even sizes", () => {
     expect(() => generateCyclicGraecoLatin(4, 1, 3)).toThrow()
     expect(() => generateCyclicGraecoLatin(8, 1, 3)).toThrow()
+  })
+})
+
+describe("generateMethodOfDifferenceGraecoLatin", () => {
+  it("produces Latin/orthogonal for odd m", () => {
+    const ms = [1, 3, 5]
+    for (const m of ms) {
+      const { latin, greek } = generateMethodOfDifferenceGraecoLatin(m)
+      expect(latin.length).toBe(3 * m + 1)
+      expect(greek.length).toBe(3 * m + 1)
+      expect(isLatinSquare(latin)).toBe(true)
+      expect(isLatinSquare(greek)).toBe(true)
+      expect(arePairsOrthogonal(latin, greek)).toBe(true)
+    }
+  })
+
+  it("matches the 10x10 pair from the paper for m=3", () => {
+    const { latin, greek } = generateMethodOfDifferenceGraecoLatin(3)
+    const A = [
+      [0, 6, 5, 4, 9, 8, 7, 1, 2, 3],
+      [7, 1, 0, 6, 5, 9, 8, 2, 3, 4],
+      [8, 7, 2, 1, 0, 6, 9, 3, 4, 5],
+      [9, 8, 7, 3, 2, 1, 0, 4, 5, 6],
+      [1, 9, 8, 7, 4, 3, 2, 5, 6, 0],
+      [3, 2, 9, 8, 7, 5, 4, 6, 0, 1],
+      [5, 4, 3, 9, 8, 7, 6, 0, 1, 2],
+      [2, 3, 4, 5, 6, 0, 1, 7, 8, 9],
+      [4, 5, 6, 0, 1, 2, 3, 8, 9, 7],
+      [6, 0, 1, 2, 3, 4, 5, 9, 7, 8],
+    ]
+    const B = [
+      [0, 7, 8, 9, 1, 3, 5, 2, 4, 6],
+      [6, 1, 7, 8, 9, 2, 4, 3, 5, 0],
+      [5, 0, 2, 7, 8, 9, 3, 4, 6, 1],
+      [4, 6, 1, 3, 7, 8, 9, 5, 0, 2],
+      [9, 5, 0, 2, 4, 7, 8, 6, 1, 3],
+      [8, 9, 6, 1, 3, 5, 7, 0, 2, 4],
+      [7, 8, 9, 0, 2, 4, 6, 1, 3, 5],
+      [1, 2, 3, 4, 5, 6, 0, 7, 8, 9],
+      [2, 3, 4, 5, 6, 0, 1, 9, 7, 8],
+      [3, 4, 5, 6, 0, 1, 2, 8, 9, 7],
+    ]
+    const toPairs = (L: number[][], G: number[][]) =>
+      L.map((row, i) => row.map((a, j) => `${a}${G[i][j]}`))
+    if (
+      JSON.stringify(latin) !== JSON.stringify(A) ||
+      JSON.stringify(greek) !== JSON.stringify(B)
+    ) {
+      const diffs: { i: number; j: number; got: [number, number]; exp: [number, number] }[] = []
+      for (let i = 0; i < 10; i++) {
+        for (let j = 0; j < 10; j++) {
+          const got: [number, number] = [latin[i][j], greek[i][j]]
+          const exp: [number, number] = [A[i][j], B[i][j]]
+          if (got[0] !== exp[0] || got[1] !== exp[1]) diffs.push({ i, j, got, exp })
+        }
+      }
+      console.log(
+        "m=3 generated pair grid:\n" +
+          toPairs(latin, greek)
+            .map((r) => r.join(" "))
+            .join("\n")
+      )
+      console.log(
+        "expected pair grid:\n" +
+          toPairs(A, B)
+            .map((r) => r.join(" "))
+            .join("\n")
+      )
+      console.log("diff cells:", diffs)
+    }
+    expect(latin).toEqual(A)
+    expect(greek).toEqual(B)
   })
 })
 

--- a/src/lib/graeco-latin.test.ts
+++ b/src/lib/graeco-latin.test.ts
@@ -295,4 +295,10 @@ describe("generateGraecoLatinAuto selection", () => {
     const cyc15 = generateCyclicGraecoLatin(15)
     expect(auto15).toEqual(cyc15)
   })
+
+  it("uses method-of-difference for n=10", () => {
+    const auto10 = generateGraecoLatinAuto(10)
+    const diff10 = generateMethodOfDifferenceGraecoLatin(3)
+    expect(auto10).toEqual(diff10)
+  })
 })

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -165,6 +165,7 @@ export function generateGraecoLatinAuto(
   }
 ): GraecoLatinSquare {
   const dec = primePowerDecomposition(n)
+  if (n === 4) return generateMethodOfDifferenceGraecoLatin(1)
   if (n % 2 === 0) {
     if (n === 10) return generateMethodOfDifferenceGraecoLatin(3)
     const ffEven = generateFiniteFieldGraecoLatin(n, opts?.matrix)

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -179,6 +179,11 @@ export function generateGraecoLatinAuto(
   return generateCyclicGraecoLatin(n, opts?.latinMultiplier ?? 1, opts?.greekMultiplier ?? 2)
 }
 
+export function isMethodOfDifferenceSupported(n: number): boolean {
+  const m = (n - 1) / 3
+  return Number.isInteger(m) && m % 2 === 1 && m >= 1
+}
+
 // From Bose, R. C., Shrikhande, S. S., & Parker, E. T. (1960). Further results on the construction of mutually orthogonal Latin squares and the falsity of Euler's conjecture. Canadian Journal of Mathematics, 12, 189-203.
 export function generateMethodOfDifferenceGraecoLatin(m: number): GraecoLatinSquare {
   if (m % 2 === 0 || m < 1) throw new Error("m must be odd and >= 1")
@@ -242,7 +247,7 @@ export function generateMethodOfDifferenceGraecoLatin(m: number): GraecoLatinSqu
       Astar[0].push(x(r))
       Astar[1].push(x(c))
       Astar[2].push(x((r + c) % m))
-      Astar[3].push(x((((2 * r + c) % m) + m) % m))
+      Astar[3].push(x((2 * r + c) % m))
     }
   }
   for (let i = 0; i < 4; i++) rows[i].push(...Astar[i])

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -176,3 +176,83 @@ export function generateGraecoLatinAuto(
   }
   return generateCyclicGraecoLatin(n, opts?.latinMultiplier ?? 1, opts?.greekMultiplier ?? 2)
 }
+
+// From Bose, R. C., Shrikhande, S. S., & Parker, E. T. (1960). Further results on the construction of mutually orthogonal Latin squares and the falsity of Euler's conjecture. Canadian Journal of Mathematics, 12, 189-203.
+export function generateMethodOfDifferenceGraecoLatin(m: number): GraecoLatinSquare {
+  if (m % 2 === 0 || m < 1) throw new Error("m must be odd and >= 1")
+  const n = 2 * m + 1
+  const v = 3 * m + 1
+
+  const x = (j: number) => n + j
+
+  const A0: number[][] = [[], [], [], []]
+  for (let j = 0; j < m; j++) {
+    const r = j + 1
+    const s = 2 * m - j
+    const X = x(j)
+    A0[0].push(0)
+    A0[1].push(r)
+    A0[2].push(s)
+    A0[3].push(X)
+
+    A0[0].push(r)
+    A0[1].push(0)
+    A0[2].push(X)
+    A0[3].push(s)
+
+    A0[0].push(s)
+    A0[1].push(X)
+    A0[2].push(0)
+    A0[3].push(r)
+
+    A0[0].push(X)
+    A0[1].push(s)
+    A0[2].push(r)
+    A0[3].push(0)
+  }
+
+  const addShift = (arr: number[][], shift: number) => {
+    const out: number[][] = [[], [], [], []]
+    for (let i = 0; i < 4; i++) {
+      for (let c = 0; c < arr[i].length; c++) {
+        const v0 = arr[i][c]
+        out[i].push(v0 < n ? (v0 + shift) % n : v0)
+      }
+    }
+    return out
+  }
+
+  const rows: number[][] = [[], [], [], []]
+  for (let i = 0; i < n; i++) {
+    rows[0].push(i)
+    rows[1].push(i)
+    rows[2].push(i)
+    rows[3].push(i)
+  }
+  for (let s = 0; s < n; s++) {
+    const As = addShift(A0, s)
+    for (let i = 0; i < 4; i++) rows[i].push(...As[i])
+  }
+
+  const Astar: number[][] = [[], [], [], []]
+  for (let r = 0; r < m; r++) {
+    for (let c = 0; c < m; c++) {
+      Astar[0].push(x(r))
+      Astar[1].push(x(c))
+      Astar[2].push(x((r + c) % m))
+      Astar[3].push(x((((2 * r + c) % m) + m) % m))
+    }
+  }
+  for (let i = 0; i < 4; i++) rows[i].push(...Astar[i])
+
+  const latin: number[][] = Array.from({ length: v }, () => Array(v).fill(0))
+  const greek: number[][] = Array.from({ length: v }, () => Array(v).fill(0))
+  const cols = rows[0].length
+  for (let k = 0; k < cols; k++) {
+    const r = rows[0][k]
+    const c = rows[1][k]
+    latin[r][c] = rows[2][k]
+    greek[r][c] = rows[3][k]
+  }
+  return { latin, greek }
+}

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -166,6 +166,7 @@ export function generateGraecoLatinAuto(
 ): GraecoLatinSquare {
   const dec = primePowerDecomposition(n)
   if (n % 2 === 0) {
+    if (n === 10) return generateMethodOfDifferenceGraecoLatin(3)
     const ffEven = generateFiniteFieldGraecoLatin(n, opts?.matrix)
     if (ffEven) return ffEven
     throw new Error("No valid construction for even size without finite field support")

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand"
 
+export type Method = "auto" | "finite" | "cyclic" | "klein4" | "difference"
+
 interface GraecoLatinState {
   size: number
   paletteType: "pastel" | "grayscale" | "scientific_american_59"
@@ -7,14 +9,14 @@ interface GraecoLatinState {
   foregroundShift: number
   latinMultiplier: number
   greekMultiplier: number
-  method: "auto" | "finite" | "cyclic" | "klein4" | "difference"
+  method: Method
   setSize: (size: number) => void
   setPaletteType: (paletteType: "pastel" | "grayscale" | "scientific_american_59") => void
   setBackgroundShift: (shift: number) => void
   setForegroundShift: (shift: number) => void
   setLatinMultiplier: (multiplier: number) => void
   setGreekMultiplier: (multiplier: number) => void
-  setMethod: (method: "auto" | "finite" | "cyclic" | "klein4" | "difference") => void
+  setMethod: (method: Method) => void
 }
 
 export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
@@ -32,5 +34,5 @@ export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
   setForegroundShift: (foregroundShift: number) => set({ foregroundShift }),
   setLatinMultiplier: (latinMultiplier: number) => set({ latinMultiplier }),
   setGreekMultiplier: (greekMultiplier: number) => set({ greekMultiplier }),
-  setMethod: (method: "auto" | "finite" | "cyclic" | "klein4" | "difference") => set({ method }),
+  setMethod: (method: Method) => set({ method }),
 }))

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -7,14 +7,14 @@ interface GraecoLatinState {
   foregroundShift: number
   latinMultiplier: number
   greekMultiplier: number
-  method: "auto" | "finite" | "cyclic" | "klein4"
+  method: "auto" | "finite" | "cyclic" | "klein4" | "difference"
   setSize: (size: number) => void
   setPaletteType: (paletteType: "pastel" | "grayscale" | "scientific_american_59") => void
   setBackgroundShift: (shift: number) => void
   setForegroundShift: (shift: number) => void
   setLatinMultiplier: (multiplier: number) => void
   setGreekMultiplier: (multiplier: number) => void
-  setMethod: (method: "auto" | "finite" | "cyclic" | "klein4") => void
+  setMethod: (method: "auto" | "finite" | "cyclic" | "klein4" | "difference") => void
 }
 
 export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
@@ -32,5 +32,5 @@ export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
   setForegroundShift: (foregroundShift: number) => set({ foregroundShift }),
   setLatinMultiplier: (latinMultiplier: number) => set({ latinMultiplier }),
   setGreekMultiplier: (greekMultiplier: number) => set({ greekMultiplier }),
-  setMethod: (method: "auto" | "finite" | "cyclic" | "klein4") => set({ method }),
+  setMethod: (method: "auto" | "finite" | "cyclic" | "klein4" | "difference") => set({ method }),
 }))


### PR DESCRIPTION
### Summary
- **New**: `generateMethodOfDifferenceGraecoLatin(m)` + `isMethodOfDifferenceSupported(n)` per Bose–Shrikhande–Parker (1960).
- **Auto**: Uses method-of-difference for `n = 4` and `n = 10`; preserves existing fallbacks elsewhere.
- **UI**: Adds `10×10` size and `Method of Difference` option (gated by support). Invalid selections auto-reset.
- **State**: Introduces `Method` union including `"difference"`.
- **Tests**: Validates m ∈ {1,3,5}; golden 10×10 pair; `auto(10) === difference(m=3)`.

### Files
- `src/lib/graeco-latin.ts`: Algorithm + auto-selection updates.
- `src/components/controls.tsx`, `src/components/display.tsx`: Method wiring and gating.
- `src/lib/store.ts`: `Method` type integration.
- `src/lib/graeco-latin.test.ts`: New coverage and golden case.