### PR TITLE
Add direct product of two squares & extend range to 13x13

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -33,6 +33,7 @@ export default function Controls() {
     latinMultiplier,
     greekMultiplier,
     method,
+    direct4x4Method,
     setSize,
     setPaletteType,
     setBackgroundShift,
@@ -40,6 +41,7 @@ export default function Controls() {
     setLatinMultiplier,
     setGreekMultiplier,
     setMethod,
+    setDirect4x4Method,
   } = useGraecoLatinStore()
 
   const availableMultipliers = getAllMultipliers(size)
@@ -52,6 +54,7 @@ export default function Controls() {
     if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
     if (newSize !== 4 && method === "klein4") setMethod("auto")
     if (!primePowerDecomposition(newSize) && method === "finite") setMethod("auto")
+    if (newSize !== 12 && method === "direct") setMethod("auto")
     const newMultipliers = getAllMultipliers(newSize)
     if (!newMultipliers.includes(latinMultiplier)) {
       setLatinMultiplier(newMultipliers[0] || 1)
@@ -109,6 +112,9 @@ export default function Controls() {
                   <SelectItem value="8">8×8</SelectItem>
                   <SelectItem value="9">9×9</SelectItem>
                   <SelectItem value="10">10×10</SelectItem>
+                  <SelectItem value="11">11×11</SelectItem>
+                  <SelectItem value="12">12×12</SelectItem>
+                  <SelectItem value="13">13×13</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -132,6 +138,9 @@ export default function Controls() {
                   </SelectItem>
                   <SelectItem value="difference" disabled={!isMethodOfDifferenceSupported(size)}>
                     Method of Difference
+                  </SelectItem>
+                  <SelectItem value="direct" disabled={size !== 12}>
+                    Direct Product
                   </SelectItem>
                 </SelectContent>
               </Select>
@@ -174,6 +183,24 @@ export default function Controls() {
                         {multiplier}
                       </SelectItem>
                     ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {method === "direct" && size === 12 && (
+              <div>
+                <Label htmlFor="direct4x4">4×4 component method</Label>
+                <Select
+                  value={direct4x4Method}
+                  onValueChange={(value) => setDirect4x4Method(value as "finite" | "difference")}
+                >
+                  <SelectTrigger className="mt-2 bg-white">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="finite">4×4 via Finite Field</SelectItem>
+                    <SelectItem value="difference">4×4 via Method of Difference</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { downloadPNG, downloadSVG } from "@/lib/downloads"
 import {
+  directProductGraecoLatin,
   type GraecoLatinSquare,
   generateCyclicGraecoLatin,
   generateFiniteFieldGraecoLatin,
@@ -29,6 +30,7 @@ export default function Display() {
     latinMultiplier,
     greekMultiplier,
     method,
+    direct4x4Method,
   } = useGraecoLatinStore()
 
   const svgRef = useRef<SVGSVGElement>(null)
@@ -43,6 +45,13 @@ export default function Display() {
     } else {
       square = generateGraecoLatinAuto(size, { latinMultiplier, greekMultiplier })
     }
+  } else if (method === "direct" && size === 12) {
+    const A = generateCyclicGraecoLatin(3)
+    const B =
+      direct4x4Method === "difference"
+        ? generateMethodOfDifferenceGraecoLatin(1)
+        : generateKlein4GraecoLatin()
+    square = directProductGraecoLatin(A, B)
   } else if (method === "finite") {
     const ff = generateFiniteFieldGraecoLatin(size)
     if (ff) square = ff

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -50,7 +50,7 @@ export default function Display() {
     const B =
       direct4x4Method === "difference"
         ? generateMethodOfDifferenceGraecoLatin(1)
-        : generateKlein4GraecoLatin()
+        : generateFiniteFieldGraecoLatin(4)!
     square = directProductGraecoLatin(A, B)
   } else if (method === "finite") {
     const ff = generateFiniteFieldGraecoLatin(size)

--- a/src/lib/graeco-latin.test.ts
+++ b/src/lib/graeco-latin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   areMultipliersValid,
+  directProductGraecoLatin,
   generateCyclicGraecoLatin,
   generateFiniteFieldGraecoLatin,
   generateGraecoLatinAuto,
@@ -273,6 +274,41 @@ describe("generateFiniteFieldGraecoLatin", () => {
       }
     }
     expect(failures).toHaveLength(0)
+  })
+})
+
+describe("directProductGraecoLatin", () => {
+  it("constructs 12 = 3*4 from 3 and 4", () => {
+    const A = generateCyclicGraecoLatin(3)
+    const B = generateKlein4GraecoLatin()
+    const C = directProductGraecoLatin(A, B)
+    expect(C.latin.length).toBe(12)
+    expect(C.greek.length).toBe(12)
+    const isLatin = (M: number[][]) => {
+      const n = M.length
+      for (let i = 0; i < n; i++) if (new Set(M[i]).size !== n) return false
+      for (let j = 0; j < n; j++) {
+        const s = new Set<number>()
+        for (let i = 0; i < n; i++) s.add(M[i][j])
+        if (s.size !== n) return false
+      }
+      return true
+    }
+    const ortho = (L: number[][], G: number[][]) => {
+      const n = L.length
+      const seen = new Set<number>()
+      for (let i = 0; i < n; i++) {
+        for (let j = 0; j < n; j++) {
+          const key = L[i][j] * (n * n) + G[i][j]
+          if (seen.has(key)) return false
+          seen.add(key)
+        }
+      }
+      return seen.size === n * n
+    }
+    expect(isLatin(C.latin)).toBe(true)
+    expect(isLatin(C.greek)).toBe(true)
+    expect(ortho(C.latin, C.greek)).toBe(true)
   })
 })
 

--- a/src/lib/graeco-latin.test.ts
+++ b/src/lib/graeco-latin.test.ts
@@ -236,7 +236,7 @@ describe("generateKlein4GraecoLatin", () => {
 })
 
 describe("generateFiniteFieldGraecoLatin", () => {
-  const sizes = [3, 4, 5, 7, 8, 9]
+  const sizes = [3, 4, 5, 7, 8, 9, 11, 13]
   it("produces Latin/orthogonal for prime powers via finite field", () => {
     const failures: number[] = []
     for (const n of sizes) {

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -192,7 +192,7 @@ export function generateGraecoLatinAuto(
 ): GraecoLatinSquare {
   if (n === 12) {
     const a3 = generateCyclicGraecoLatin(3)
-    const b4 = generateKlein4GraecoLatin()
+    const b4 = generateFiniteFieldGraecoLatin(4)!
     return directProductGraecoLatin(a3, b4)
   }
   const dec = primePowerDecomposition(n)

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -190,6 +190,11 @@ export function generateGraecoLatinAuto(
     greekMultiplier?: number
   }
 ): GraecoLatinSquare {
+  if (n === 12) {
+    const a3 = generateCyclicGraecoLatin(3)
+    const b4 = generateKlein4GraecoLatin()
+    return directProductGraecoLatin(a3, b4)
+  }
   const dec = primePowerDecomposition(n)
   if (n === 4) return generateMethodOfDifferenceGraecoLatin(1)
   if (n % 2 === 0) {

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -156,6 +156,32 @@ export function generateFiniteFieldGraecoLatin(
   return { latin, greek }
 }
 
+export function directProductGraecoLatin(
+  A: GraecoLatinSquare,
+  B: GraecoLatinSquare
+): GraecoLatinSquare {
+  const m = A.latin.length
+  const n = B.latin.length
+  const size = m * n
+  const latin: number[][] = Array.from({ length: size }, () => Array(size).fill(0))
+  const greek: number[][] = Array.from({ length: size }, () => Array(size).fill(0))
+  for (let i = 0; i < m; i++) {
+    for (let j = 0; j < m; j++) {
+      const aL = A.latin[i][j]
+      const aG = A.greek[i][j]
+      for (let i2 = 0; i2 < n; i2++) {
+        for (let j2 = 0; j2 < n; j2++) {
+          const r = i * n + i2
+          const c = j * n + j2
+          latin[r][c] = aL * n + B.latin[i2][j2]
+          greek[r][c] = aG * n + B.greek[i2][j2]
+        }
+      }
+    }
+  }
+  return { latin, greek }
+}
+
 export function generateGraecoLatinAuto(
   n: number,
   opts?: {

--- a/src/lib/palettes.ts
+++ b/src/lib/palettes.ts
@@ -9,19 +9,25 @@ export const PASTEL_PALETTE = [
   "#F7DC6F",
   "#BB8FCE",
   "#85C1E9",
+  "#F8C291",
+  "#F5B7B1",
+  "#A3E4D7",
 ]
 
 export const GRAYSCALE_PALETTE = [
   "#000000",
+  "#0d0d0d",
   "#1a1a1a",
   "#333333",
   "#4d4d4d",
   "#666666",
+  "#737373",
   "#808080",
   "#999999",
   "#b3b3b3",
   "#cccccc",
   "#e6e6e6",
+  "#f2f2f2",
 ]
 
 export const SCIENTIFIC_AMERICAN_59_PALETTE = [
@@ -35,6 +41,9 @@ export const SCIENTIFIC_AMERICAN_59_PALETTE = [
   "#362731",
   "#3d4966",
   "#f9f8f7",
+  "#7f6a5a",
+  "#8a9a9f",
+  "#d0c7b8",
 ]
 
 export function shiftPalette(palette: string[], shift: number): string[] {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
 
-export type Method = "auto" | "finite" | "cyclic" | "klein4" | "difference"
+export type Method = "auto" | "finite" | "cyclic" | "klein4" | "difference" | "direct"
 
 interface GraecoLatinState {
   size: number
@@ -10,6 +10,7 @@ interface GraecoLatinState {
   latinMultiplier: number
   greekMultiplier: number
   method: Method
+  direct4x4Method: "finite" | "difference"
   setSize: (size: number) => void
   setPaletteType: (paletteType: "pastel" | "grayscale" | "scientific_american_59") => void
   setBackgroundShift: (shift: number) => void
@@ -17,6 +18,7 @@ interface GraecoLatinState {
   setLatinMultiplier: (multiplier: number) => void
   setGreekMultiplier: (multiplier: number) => void
   setMethod: (method: Method) => void
+  setDirect4x4Method: (m: "finite" | "difference") => void
 }
 
 export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
@@ -27,6 +29,7 @@ export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
   latinMultiplier: 1,
   greekMultiplier: 2,
   method: "auto",
+  direct4x4Method: "finite",
   setSize: (size: number) => set({ size }),
   setPaletteType: (paletteType: "pastel" | "grayscale" | "scientific_american_59") =>
     set({ paletteType }),
@@ -35,4 +38,5 @@ export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
   setLatinMultiplier: (latinMultiplier: number) => set({ latinMultiplier }),
   setGreekMultiplier: (greekMultiplier: number) => set({ greekMultiplier }),
   setMethod: (method: Method) => set({ method }),
+  setDirect4x4Method: (direct4x4Method: "finite" | "difference") => set({ direct4x4Method }),
 }))


### PR DESCRIPTION
### Summary
- **Feature: Direct Product (12×12)**: Added `directProductGraecoLatin` and integrated it into auto-generation for n=12; selectable in UI as “Direct Product” (enabled only for 12×12).
- **4×4 component choice**: New control to pick the 4×4 construction used in the product: “Finite Field” or “Method of Difference”.
- **UI updates**: Size options extended to 11–13; method dropdown includes “Direct Product” (guarded by size=12); method auto-resets if incompatible.
- **State management**: Store now supports `method: "direct"` and `direct4x4Method` with setter; default `direct4x4Method` is “finite”.
- **Rendering logic**: `display.tsx` builds 12×12 via direct product of 3×3 cyclic and chosen 4×4 (finite field or difference).
- **Tests**: Added tests for direct product construction of 12 from 3×4; expanded finite field tests to include sizes 11 and 13.
- **Palettes**: Expanded pastel, grayscale, and Scientific American ’59 palettes with additional shades.