### PR TITLE
Remove Klein four implementation

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -52,7 +52,6 @@ export default function Controls() {
     const diffValid = isMethodOfDifferenceSupported(newSize)
     if (method === "difference" && !diffValid) setMethod("auto")
     if (newSize % 2 === 0 && method === "cyclic") setMethod("auto")
-    if (newSize !== 4 && method === "klein4") setMethod("auto")
     if (!primePowerDecomposition(newSize) && method === "finite") setMethod("auto")
     if (newSize !== 12 && method === "direct") setMethod("auto")
     const newMultipliers = getAllMultipliers(newSize)
@@ -132,9 +131,6 @@ export default function Controls() {
                   </SelectItem>
                   <SelectItem value="cyclic" disabled={size % 2 === 0}>
                     Cyclic
-                  </SelectItem>
-                  <SelectItem value="klein4" disabled={size !== 4}>
-                    Klein 4 (4×4)
                   </SelectItem>
                   <SelectItem value="difference" disabled={!isMethodOfDifferenceSupported(size)}>
                     Method of Difference

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -9,7 +9,6 @@ import {
   generateCyclicGraecoLatin,
   generateFiniteFieldGraecoLatin,
   generateGraecoLatinAuto,
-  generateKlein4GraecoLatin,
   generateMethodOfDifferenceGraecoLatin,
   isMethodOfDifferenceSupported,
 } from "@/lib/graeco-latin"
@@ -36,9 +35,7 @@ export default function Display() {
   const svgRef = useRef<SVGSVGElement>(null)
 
   let square: GraecoLatinSquare
-  if (method === "klein4" && size === 4) {
-    square = generateKlein4GraecoLatin()
-  } else if (method === "difference") {
+  if (method === "difference") {
     const m = (size - 1) / 3
     if (isMethodOfDifferenceSupported(size)) {
       square = generateMethodOfDifferenceGraecoLatin(m)
@@ -55,7 +52,6 @@ export default function Display() {
   } else if (method === "finite") {
     const ff = generateFiniteFieldGraecoLatin(size)
     if (ff) square = ff
-    else if (size === 4) square = generateKlein4GraecoLatin()
     else if (size % 2 !== 0)
       square = generateCyclicGraecoLatin(size, latinMultiplier, greekMultiplier)
     else square = generateGraecoLatinAuto(size, { latinMultiplier, greekMultiplier })

--- a/src/lib/graeco-latin.test.ts
+++ b/src/lib/graeco-latin.test.ts
@@ -5,7 +5,6 @@ import {
   generateCyclicGraecoLatin,
   generateFiniteFieldGraecoLatin,
   generateGraecoLatinAuto,
-  generateKlein4GraecoLatin,
   generateMethodOfDifferenceGraecoLatin,
   getAllMultipliers,
 } from "./graeco-latin"
@@ -186,55 +185,6 @@ describe("generateMethodOfDifferenceGraecoLatin", () => {
   })
 })
 
-describe("generateKlein4GraecoLatin", () => {
-  it("produces 4x4 Latin squares and orthogonal pairs for default M", () => {
-    const { latin, greek } = generateKlein4GraecoLatin()
-    expect(latin.length).toBe(4)
-    expect(greek.length).toBe(4)
-    expect(isLatinSquare(latin)).toBe(true)
-    expect(isLatinSquare(greek)).toBe(true)
-    expect(arePairsOrthogonal(latin, greek)).toBe(true)
-  })
-
-  it("matches the explicit example pairs for M=[[0,1],[1,1]] up to labels", () => {
-    const { latin, greek } = generateKlein4GraecoLatin([
-      [0, 1],
-      [1, 1],
-    ])
-    const expectedPairs = [
-      [
-        [0, 0],
-        [1, 2],
-        [2, 3],
-        [3, 1],
-      ],
-      [
-        [1, 1],
-        [0, 3],
-        [3, 2],
-        [2, 0],
-      ],
-      [
-        [2, 2],
-        [3, 0],
-        [0, 1],
-        [1, 3],
-      ],
-      [
-        [3, 3],
-        [2, 1],
-        [1, 0],
-        [0, 2],
-      ],
-    ]
-    for (let i = 0; i < 4; i++) {
-      for (let j = 0; j < 4; j++) {
-        expect([latin[i][j], greek[i][j]]).toEqual(expectedPairs[i][j])
-      }
-    }
-  })
-})
-
 describe("generateFiniteFieldGraecoLatin", () => {
   const sizes = [3, 4, 5, 7, 8, 9, 11, 13]
   it("produces Latin/orthogonal for prime powers via finite field", () => {
@@ -280,7 +230,7 @@ describe("generateFiniteFieldGraecoLatin", () => {
 describe("directProductGraecoLatin", () => {
   it("constructs 12 = 3*4 from 3 and 4", () => {
     const A = generateCyclicGraecoLatin(3)
-    const B = generateKlein4GraecoLatin()
+    const B = generateFiniteFieldGraecoLatin(4)!
     const C = directProductGraecoLatin(A, B)
     expect(C.latin.length).toBe(12)
     expect(C.greek.length).toBe(12)

--- a/src/lib/graeco-latin.ts
+++ b/src/lib/graeco-latin.ts
@@ -59,35 +59,6 @@ export function generateCyclicGraecoLatin(
   return { latin, greek }
 }
 
-export function generateKlein4GraecoLatin(
-  M?: [[number, number], [number, number]]
-): GraecoLatinSquare {
-  const matrix = M ?? [
-    [0, 1],
-    [1, 1],
-  ]
-  const applyM = (v: number) => {
-    const x = v & 1
-    const y = (v >> 1) & 1
-    const xPrime = (matrix[0][0] * x + matrix[0][1] * y) & 1
-    const yPrime = (matrix[1][0] * x + matrix[1][1] * y) & 1
-    return (yPrime << 1) | xPrime
-  }
-  const size = 4
-  const latin: number[][] = []
-  const greek: number[][] = []
-  for (let r = 0; r < size; r++) {
-    latin[r] = []
-    greek[r] = []
-    for (let c = 0; c < size; c++) {
-      const mxc = applyM(c)
-      latin[r][c] = r ^ c
-      greek[r][c] = r ^ mxc
-    }
-  }
-  return { latin, greek }
-}
-
 export function generateFiniteFieldGraecoLatin(
   n: number,
   matrix?: [[number, number], [number, number]]

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
 
-export type Method = "auto" | "finite" | "cyclic" | "klein4" | "difference" | "direct"
+export type Method = "auto" | "finite" | "cyclic" | "difference" | "direct"
 
 interface GraecoLatinState {
   size: number


### PR DESCRIPTION
### Remove Klein-4 construction; unify 4×4 via finite field

- **Removed Klein-4 method**: Deleted `generateKlein4GraecoLatin` and its tests.
- **UI cleanup**: Removed `Klein 4 (4×4)` option from `components/controls.tsx`; dropped Klein-4 logic from `components/display.tsx`.
- **Type updates**: Removed `"klein4"` from `Method` in `lib/store.ts`.
- **Test updates**: Replaced Klein-4 usage with `generateFiniteFieldGraecoLatin(4)` in direct product test.
- **Behavior**: 4×4 squares now use the finite-field construction path; no Klein-4 fallbacks remain.