### PR TITLE
Add palette order randomizer

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -1,5 +1,6 @@
-import { HelpCircle, Palette } from "lucide-react"
+import { HelpCircle, Palette, Shuffle } from "lucide-react"
 import { useState } from "react"
+import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
@@ -22,6 +23,7 @@ import {
   PASTEL_PALETTE,
   SCIENTIFIC_AMERICAN_59_PALETTE,
   shiftPalette,
+  shufflePalette,
 } from "@/lib/palettes"
 import type { Method } from "@/lib/store"
 import { useGraecoLatinStore } from "@/lib/store"
@@ -33,6 +35,7 @@ export default function Controls() {
     paletteType,
     backgroundShift,
     foregroundShift,
+    paletteSeed,
     latinMultiplier,
     greekMultiplier,
     method,
@@ -41,6 +44,7 @@ export default function Controls() {
     setPaletteType,
     setBackgroundShift,
     setForegroundShift,
+    setPaletteSeed,
     setLatinMultiplier,
     setGreekMultiplier,
     setMethod,
@@ -85,8 +89,14 @@ export default function Controls() {
       : paletteType === "grayscale"
         ? GRAYSCALE_PALETTE
         : SCIENTIFIC_AMERICAN_59_PALETTE
-  const backgroundColors = shiftPalette(basePalette, backgroundShift).slice(0, size)
-  const foregroundColors = shiftPalette(basePalette, foregroundShift).slice(0, size)
+  const shuffled = shufflePalette(basePalette, paletteSeed)
+  const backgroundColors = shiftPalette(shuffled, backgroundShift).slice(0, size)
+  const foregroundColors = shiftPalette(shuffled, foregroundShift).slice(0, size)
+
+  const randomizePalette = () => {
+    const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
+    setPaletteSeed(seed)
+  }
 
   return (
     <ScrollArea className="h-full">
@@ -247,7 +257,15 @@ export default function Controls() {
             )}
 
             <div>
-              <Label htmlFor="palette">Color Palette</Label>
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <Label htmlFor="palette">Color Palette</Label>
+                </div>
+                <Button onClick={randomizePalette} className="bg-white" variant="outline" size="sm">
+                  <Shuffle className="h-4 w-4" />
+                  Randomize
+                </Button>
+              </div>
               <Select
                 value={paletteType}
                 onValueChange={(value) =>

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -89,9 +89,10 @@ export default function Controls() {
       : paletteType === "grayscale"
         ? GRAYSCALE_PALETTE
         : SCIENTIFIC_AMERICAN_59_PALETTE
-  const shuffled = shufflePalette(basePalette, paletteSeed)
-  const backgroundColors = shiftPalette(shuffled, backgroundShift).slice(0, size)
-  const foregroundColors = shiftPalette(shuffled, foregroundShift).slice(0, size)
+  const effectivePalette =
+    paletteSeed === 0 ? basePalette : shufflePalette(basePalette, paletteSeed)
+  const backgroundColors = shiftPalette(effectivePalette, backgroundShift).slice(0, size)
+  const foregroundColors = shiftPalette(effectivePalette, foregroundShift).slice(0, size)
 
   const randomizePalette = () => {
     const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, Palette, Shuffle } from "lucide-react"
+import { HelpCircle, Palette, RotateCcw, Shuffle } from "lucide-react"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
@@ -96,6 +96,10 @@ export default function Controls() {
   const randomizePalette = () => {
     const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
     setPaletteSeed(seed)
+  }
+
+  const resetPalette = () => {
+    setPaletteSeed(0)
   }
 
   return (
@@ -261,10 +265,21 @@ export default function Controls() {
                 <div>
                   <Label htmlFor="palette">Color Palette</Label>
                 </div>
-                <Button onClick={randomizePalette} className="bg-white" variant="outline" size="sm">
-                  <Shuffle className="h-4 w-4" />
-                  Randomize
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button onClick={resetPalette} className="bg-white" variant="outline" size="sm">
+                    <RotateCcw className="h-4 w-4" />
+                    Reset
+                  </Button>
+                  <Button
+                    onClick={randomizePalette}
+                    className="bg-white"
+                    variant="outline"
+                    size="sm"
+                  >
+                    <Shuffle className="h-4 w-4" />
+                    Randomize
+                  </Button>
+                </div>
               </div>
               <Select
                 value={paletteType}

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -68,9 +68,10 @@ export default function Display() {
       : paletteType === "grayscale"
         ? GRAYSCALE_PALETTE
         : SCIENTIFIC_AMERICAN_59_PALETTE
-  const shuffled = shufflePalette(basePalette, paletteSeed)
-  const backgroundColors = shiftPalette(shuffled, backgroundShift).slice(0, size)
-  const foregroundColors = shiftPalette(shuffled, foregroundShift).slice(0, size)
+  const effectivePalette =
+    paletteSeed === 0 ? basePalette : shufflePalette(basePalette, paletteSeed)
+  const backgroundColors = shiftPalette(effectivePalette, backgroundShift).slice(0, size)
+  const foregroundColors = shiftPalette(effectivePalette, foregroundShift).slice(0, size)
 
   const cellSize = 60
   const innerSize = cellSize * 0.4

--- a/src/components/display.tsx
+++ b/src/components/display.tsx
@@ -17,6 +17,7 @@ import {
   PASTEL_PALETTE,
   SCIENTIFIC_AMERICAN_59_PALETTE,
   shiftPalette,
+  shufflePalette,
 } from "@/lib/palettes"
 import { useGraecoLatinStore } from "@/lib/store"
 
@@ -26,6 +27,7 @@ export default function Display() {
     paletteType,
     backgroundShift,
     foregroundShift,
+    paletteSeed,
     latinMultiplier,
     greekMultiplier,
     method,
@@ -66,8 +68,9 @@ export default function Display() {
       : paletteType === "grayscale"
         ? GRAYSCALE_PALETTE
         : SCIENTIFIC_AMERICAN_59_PALETTE
-  const backgroundColors = shiftPalette(basePalette, backgroundShift).slice(0, size)
-  const foregroundColors = shiftPalette(basePalette, foregroundShift).slice(0, size)
+  const shuffled = shufflePalette(basePalette, paletteSeed)
+  const backgroundColors = shiftPalette(shuffled, backgroundShift).slice(0, size)
+  const foregroundColors = shiftPalette(shuffled, foregroundShift).slice(0, size)
 
   const cellSize = 60
   const innerSize = cellSize * 0.4

--- a/src/lib/palettes.ts
+++ b/src/lib/palettes.ts
@@ -49,3 +49,25 @@ export const SCIENTIFIC_AMERICAN_59_PALETTE = [
 export function shiftPalette(palette: string[], shift: number): string[] {
   return palette.map((_color, index) => palette[(index + shift) % palette.length])
 }
+
+function mulberry32(seed: number) {
+  let t = seed + 0x6d2b79f5
+  return () => {
+    t += 0x6d2b79f5
+    let x = Math.imul(t ^ (t >>> 15), 1 | t)
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x)
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export function shufflePalette(palette: string[], seed: number): string[] {
+  const random = mulberry32(seed >>> 0)
+  const arr = palette.slice()
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1))
+    const tmp = arr[i]
+    arr[i] = arr[j]
+    arr[j] = tmp
+  }
+  return arr
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -7,6 +7,7 @@ interface GraecoLatinState {
   paletteType: "pastel" | "grayscale" | "scientific_american_59"
   backgroundShift: number
   foregroundShift: number
+  paletteSeed: number
   latinMultiplier: number
   greekMultiplier: number
   method: Method
@@ -15,6 +16,7 @@ interface GraecoLatinState {
   setPaletteType: (paletteType: "pastel" | "grayscale" | "scientific_american_59") => void
   setBackgroundShift: (shift: number) => void
   setForegroundShift: (shift: number) => void
+  setPaletteSeed: (seed: number) => void
   setLatinMultiplier: (multiplier: number) => void
   setGreekMultiplier: (multiplier: number) => void
   setMethod: (method: Method) => void
@@ -26,6 +28,7 @@ export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
   paletteType: "pastel",
   backgroundShift: 0,
   foregroundShift: 0,
+  paletteSeed: 0,
   latinMultiplier: 1,
   greekMultiplier: 2,
   method: "auto",
@@ -35,6 +38,7 @@ export const useGraecoLatinStore = create<GraecoLatinState>((set) => ({
     set({ paletteType }),
   setBackgroundShift: (backgroundShift: number) => set({ backgroundShift }),
   setForegroundShift: (foregroundShift: number) => set({ foregroundShift }),
+  setPaletteSeed: (paletteSeed: number) => set({ paletteSeed }),
   setLatinMultiplier: (latinMultiplier: number) => set({ latinMultiplier }),
   setGreekMultiplier: (greekMultiplier: number) => set({ greekMultiplier }),
   setMethod: (method: Method) => set({ method }),


### PR DESCRIPTION
### Title
Randomize palette order with seed and add UI controls

### Summary
Adds deterministic palette shuffling via a seed, exposes controls to randomize/reset, and wires the seed through rendering. Defaults to non-breaking behavior when seed is 0.

### Changes
- `src/lib/palettes.ts`
  - Add `mulberry32` PRNG and `shufflePalette(palette, seed)`
  - Keep `shiftPalette` unchanged
- `src/lib/store.ts`
  - Add `paletteSeed` to state with setter `setPaletteSeed`
  - Default `paletteSeed` to 0
- `src/components/display.tsx`
  - Use `paletteSeed` to derive `effectivePalette` via `shufflePalette` when non-zero
  - Shift colors from `effectivePalette`
- `src/components/controls.tsx`
  - Import and use `shufflePalette`
  - Add `paletteSeed` bindings and setters
  - New buttons: Reset (seed=0) and Randomize (seed=random), using shadcn `Button` and `lucide-react` `RotateCcw`/`Shuffle`
  - Shuffle base palette before applying background/foreground shifts