### PR TITLE
Fix mobile layout overflow with dvh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Display from "@/components/display"
 
 function App() {
   return (
-    <div className="h-screen overflow-hidden bg-neutral-50">
+    <div className="h-[100dvh] overflow-hidden bg-neutral-50">
       <div className="mx-auto h-full max-w-[528px] p-6 lg:max-w-7xl">
         <div className="flex h-full flex-col gap-6 lg:flex-row-reverse lg:gap-8">
           <Display />


### PR DESCRIPTION
Change root container height to `100dvh` to prevent vertical layout overflow on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f300f16-5a91-450b-a019-7ef29e3c1f2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f300f16-5a91-450b-a019-7ef29e3c1f2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

